### PR TITLE
✨ Enable the use of PascalCase component name

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -27,7 +27,7 @@ const RichTextVueRenderer: PluginObject<Options> = {
       }
     })
 
-    Vue.component('rich-text-renderer', RichTextRenderer)
+    Vue.component('RichTextRenderer', RichTextRenderer)
   }
 }
 


### PR DESCRIPTION
Make it possible to follow the official Vue.js style guide by allowing
the use of PascaleCase component name.
Registering a component with PascalCase makes it possible to either use
kebab-case or PascalCase when using this plugin.

See https://vuejs.org/v2/style-guide/#Component-name-casing-in-templates-strongly-recommended
See https://vuejs.org/v2/guide/components-registration.html#Name-Casing